### PR TITLE
fix(spirv-cross-sys): add missing SPIRV_CROSS_C_API_REFLECT define for JSON backend

### DIFF
--- a/spirv-cross-sys/build.rs
+++ b/spirv-cross-sys/build.rs
@@ -57,6 +57,7 @@ pub fn main() {
 
     if cfg!(feature = "json") {
         spvc_build.define("SPIRV_CROSS_C_API_JSON", "1");
+        spvc_build.define("SPIRV_CROSS_C_API_REFLECT", "1");
     }
 
     spvc_build.compile("spirv-cross");


### PR DESCRIPTION
# Fix: Add missing `SPIRV_CROSS_C_API_REFLECT` define for JSON backend

## Problem

When using the `json` feature of `spirv-cross-sys`, creating a JSON compiler instance fails with:

```
"The argument is invalid: Invalid backend."
```

This happens because `spvc_compiler_create_compiler()` in `spirv_cross_c.cpp` does not recognize `SPVC_BACKEND_JSON` as a valid backend at runtime.

## Root Cause

In `spirv_cross_c.cpp`, the `SPVC_BACKEND_JSON` case is guarded by `#ifdef SPIRV_CROSS_C_API_REFLECT`:

```cpp
#ifdef SPIRV_CROSS_C_API_REFLECT
    case SPVC_BACKEND_JSON:
        *compiler = context->add_compiler(std::unique_ptr<Compiler>(new CompilerReflection(std::move(*parsed_ir))));
        break;
#endif
```

However, the `json` feature in `spirv-cross-sys/build.rs` only defines `SPIRV_CROSS_C_API_JSON` and does **not** define `SPIRV_CROSS_C_API_REFLECT`. This means the JSON backend code path is compiled out, and `spvc_compiler_create_compiler` falls through to the `default` case which throws "Invalid backend".

Note that `spirv_reflect.cpp` is already unconditionally compiled (line 38 of build.rs), so the `CompilerReflection` class implementation is available — only the C API guard macro is missing.

## Fix

Add `SPIRV_CROSS_C_API_REFLECT=1` alongside `SPIRV_CROSS_C_API_JSON` in the `json` feature block of `spirv-cross-sys/build.rs`.

## Testing

- Verified that `Compiler::<Json>::new(module)` no longer returns "Invalid backend" error
- Verified that JSON compilation via `compiler.compile(&options)` produces valid JSON reflection output
- All existing `cargo test` pass
- `cargo fmt` and `cargo clippy` produce no new warnings

## Note

This PR was generated with AI assistance and has been manually tested by the contributor.
